### PR TITLE
Fix camera offset

### DIFF
--- a/client/ayon_equalizer/plugins/publish/extract_lens_distortion_nuke.py
+++ b/client/ayon_equalizer/plugins/publish/extract_lens_distortion_nuke.py
@@ -33,7 +33,7 @@ class ExtractLensDistortionNuke(publish.Extractor,
             return
 
         cam = tde4.getCurrentCamera()
-        offset = tde4.getCameraFrameOffset(cam)
+        offset = tde4.getCameraFrameOffset(cam) - 1
         staging_dir = self.staging_dir(instance)
         file_path = Path(staging_dir) / "nuke_ld_export.nk"
         attr_data = self.get_attr_values_from_data(instance.data)

--- a/client/ayon_equalizer/plugins/publish/extract_matchmove_script_maya.py
+++ b/client/ayon_equalizer/plugins/publish/extract_matchmove_script_maya.py
@@ -67,7 +67,8 @@ class ExtractMatchmoveScriptMaya(publish.Extractor,
             error_msg = "No camera point group found."
             raise KnownPublishError(error_msg)
 
-        offset = tde4.getCameraFrameOffset(tde4.getCurrentCamera())
+        # Here we subtract 1 because 3DE is computing the offset with an offset
+        offset = tde4.getCameraFrameOffset(tde4.getCurrentCamera()) - 1
         overscan_width = attr_data["overscan_percent_width"] / 100.0
         overscan_height = attr_data["overscan_percent_height"] / 100.0
 

--- a/client/ayon_equalizer/plugins/publish/extract_matchmove_script_nuke.py
+++ b/client/ayon_equalizer/plugins/publish/extract_matchmove_script_nuke.py
@@ -47,8 +47,7 @@ class ExtractMatchmoveScriptNuke(publish.Extractor,
             return
 
         cam = tde4.getCurrentCamera()
-        frame0 = tde4.getCameraFrameOffset(cam)
-        frame0 -= 1
+        frame0 = tde4.getCameraFrameOffset(cam) - 1
 
         staging_dir = self.staging_dir(instance)
         file_path = Path(staging_dir) / "nuke_export.nk"
@@ -58,7 +57,7 @@ class ExtractMatchmoveScriptNuke(publish.Extractor,
             """Return value for given key in widget."""
             if key == "file_browser":
                 return file_path.as_posix()
-            return tde4.getCameraFrameOffset(cam) \
+            return tde4.getCameraFrameOffset(cam) - 1 \
                 if key == "startframe_field" else ""
 
         # This is simulating artist clicking on "OK" button

--- a/client/ayon_equalizer/plugins/publish/extract_matchmove_script_nuke.py
+++ b/client/ayon_equalizer/plugins/publish/extract_matchmove_script_nuke.py
@@ -47,7 +47,6 @@ class ExtractMatchmoveScriptNuke(publish.Extractor,
             return
 
         cam = tde4.getCurrentCamera()
-        frame0 = tde4.getCameraFrameOffset(cam) - 1
 
         staging_dir = self.staging_dir(instance)
         file_path = Path(staging_dir) / "nuke_export.nk"


### PR DESCRIPTION
## Changelog Description
Fixes #7 

- Subtract `1` from all `tde4.getCameraFrameOffset` calls

## Testing notes:
1. Launch 3DE from AYON
2. Create then publish a matchmove product
3. Load the .ma into Maya and make sure the frame offset is correct
