### PR TITLE
Fix default value for heartbeat interval

### DIFF
--- a/client/ayon_equalizer/addon.py
+++ b/client/ayon_equalizer/addon.py
@@ -20,11 +20,11 @@ class EqualizerAddon(AYONAddon, IHostAddon):
     name = "equalizer"
     host_name = "equalizer"
     version = __version__
-    heartbeat = 500
+    heartbeat = 100
 
     def initialize(self, settings: dict[str, Any]) -> None:
         """Initialize Equalizer Addon."""
-        self.heartbeat = settings.get("heartbeat_interval", 500)
+        self.heartbeat = settings["equalizer"].get("heartbeat_interval", 100)
         self.enabled = True
 
     def add_implementation_envs(self, env: dict, _app: Any) -> None:  # noqa: ANN401

--- a/client/ayon_equalizer/api/host.py
+++ b/client/ayon_equalizer/api/host.py
@@ -323,7 +323,7 @@ class EqualizerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_loader_plugin_path(LOAD_PATH)
         register_creator_plugin_path(CREATE_PATH)
 
-        heartbeat_interval = os.getenv("AYON_TDE4_HEARTBEAT_INTERVAL") or 10
+        heartbeat_interval = os.getenv("AYON_TDE4_HEARTBEAT_INTERVAL") or 100
         tde4.setTimerCallbackFunction(
             "EqualizerHost._timer", int(heartbeat_interval))
 

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -8,11 +8,12 @@ class EqualizerSettings(BaseSettingsModel):
     """3DEqualizer Addon Settings."""
 
     heartbeat_interval: int = SettingsField(
-        500, title="Heartbeat Interval",
+        100, title="Heartbeat Interval",
         description=(
             "The interval in milliseconds to pass"
-            "control to 3D Equalizer. Can affect"
-            "responsiveness of the application.")
+            "control to Qt UI. Value like 100 means it will be "
+            "passed every 10x per second. Recommended value is 100 - 50 "
+            "(20x per second).")
         )
 
     create: EqualizerCreatorPlugins = SettingsField(


### PR DESCRIPTION
Clarify description of the value in the settings, fix passing of the value from the settings.

## Changelog Description
Clarify description of the value in the settings, fix passing of the value from the setting. `heartbeat_interval` is how often Qt events are processed in milliseconds. Default value 100 means it will be processed 10x per second. Value like 50 means it will be processed 20 times per second.

## Additional review information
Default value 100 means it will be processed 10x per second. Value like 50 means it will be processed 20 times per second.

## Testing notes:
Set some heartbeat interval value in the settings. Printing `AYON_TDE4_HEARTBEAT_INTERVAL` in the 3dequalizer Python console should show the value set.
