### PR TITLE
Chore: Allow per project addon version

### DIFF
--- a/.github/workflows/pr_linting.yml
+++ b/.github/workflows/pr_linting.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v3
+      - uses: astral-sh/ruff-action@v3
         with:
           # until dependencies in pyproject.toml are made "standard" and not poetry-based
           version: ">=0.11.10,<0.12.0"

--- a/.github/workflows/pr_linting.yml
+++ b/.github/workflows/pr_linting.yml
@@ -21,4 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: chartboost/ruff-action@v3
+        with:
+          # until dependencies in pyproject.toml are made "standard" and not poetry-based
+          version: ">=0.11.10,<0.12.0"

--- a/package.py
+++ b/package.py
@@ -3,8 +3,8 @@ name = "equalizer"
 title = "3DEqualizer"
 version = "0.1.2+dev"
 app_host_name = "equalizer"
-
 client_dir = "ayon_equalizer"
+project_can_override_addon_version = True
 
 ayon_server_version = ">1.3.0"
 ayon_required_addons = {


### PR DESCRIPTION
## Changelog Description
Addon can be used in per-project bundles.

## Additional informatio
I didn't find any conflicts that would not allow to use the addon in per project bundles.

## Testing notes:
1. Addon can be used in per-project bundles.
