### PR TITLE
Fixed "`angleMod360` is not defined" on Publish

### DIFF
--- a/client/ayon_equalizer/plugins/publish/extract_matchmove_script_nuke.py
+++ b/client/ayon_equalizer/plugins/publish/extract_matchmove_script_nuke.py
@@ -79,7 +79,7 @@ class ExtractMatchmoveScriptNuke(publish.Extractor,
             with exporter_path.open() as f:
                 script = f.read()
             self.log.debug("Importing %s", exporter_path.as_posix())
-            exec(script)  # noqa: S102
+            exec(script, {"tde4": tde4})  # noqa: S102
 
         # create representation data
         if "representations" not in instance.data:


### PR DESCRIPTION
## Changelog Description
Successfully runs the 3de4 nuke export python script without errors relating to recursive calls to `angleMod360`
